### PR TITLE
Update plugin link to github, Remove old crt requirements

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -44,7 +44,7 @@ class Plugin extends Base
 
     public function getPluginHomepage()
     {
-        return 'http://tj.mk';
+        return 'https://github.com/trajche/SamlAuth';
     }
 
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,6 @@ Download the plugin and upload it to the /plugins directory of your Kanboard ins
 
 After filling out all of the fields, click the **Save** button before clicking **Generate Metadata**.
 
-## Requirements
-
-This plugin expects to find the private/public certs for the server as well as the public cert for the IDP in `/var/kanboard-certs`. These should be called:
-
-* `sp-private.crt`
-* `sp-public.crt`
-* `idp-public.crt`
-
-They should also be readable by your webserver user. (e.g. `apache`, `nginx`, etc.)
-
 ### Webserver
 
 This plugin expects to have the [DOM extension](https://secure.php.net/en/dom) for php. This can be installed on Debian / Ubuntu using:


### PR DESCRIPTION
The plugin should link to documentation on the project. I can't find that at tj.mk anymore but can on this GitHub so I think it should link there. Also I was confused during implentation about the certificate file requirements and reviewing the repo see they should have been removed with #9 but were missed. 