### PR TITLE
Fix role error and not change roles after changes.

### DIFF
--- a/User/SamlUserProvider.php
+++ b/User/SamlUserProvider.php
@@ -36,7 +36,7 @@ class SamlUserProvider implements UserProviderInterface
      * @access public
      * @param  string $username
      */
-    public function __construct($username, $email, $name, $role)
+    public function __construct($username, $email, $name, $role = '')
     {
         $this->username = $username;
         $this->email = $email;


### PR DESCRIPTION
On the file SamlAuth/Auth/SamlAuth.php, an object of SamlUserProvider is created and 3 parameters are passed, while the constructor expects 4. I couldn't find a way to extract the information on roles at the point I was looking on. This proposed change would leave the call in SamlAuth/Auth/SamlAuth.php unaltered while adding the default value other UserProviders return.